### PR TITLE
Account for when token's last_used_at is missing

### DIFF
--- a/TokenRemover/rootfs/run.py
+++ b/TokenRemover/rootfs/run.py
@@ -68,6 +68,9 @@ def tokenremover(retention_days, active_days):
             continue
         
         if int(active_days) < 999:
+            if token["last_used_at"] is None:
+                continue
+
             date_str = token["last_used_at"]
             yr, mnth, d, hr, mnt, scnd = date_str[:date_str.index(".")].translate(date_str.maketrans("T:.", "---")).split("-")
             last_used_date = datetime(int(yr), int(mnth), int(d), int(hr), int(mnt))


### PR DESCRIPTION
For some reason this was missing on a lot of my tokens and it causes cascading failures. Since these tokens were never used, it stands to reason it's fine to remove them.

Please merge. It's tested and works.

Thanks!